### PR TITLE
chore: pull before standard-version and do not push

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "test": "jest --coverage=false",
     "test.coverage": "jest",
-    "release": "git checkout master && git pull origin master && standard-version && git push --follow-tags origin master",
+    "release": "git checkout master && git pull origin master && standard-version",
     "lint": "tslint -p ./tsconfig.base.json",
     "build": "npm run build:clear && tsc && npm run build:browser && npm run build:es && npm run build:umd",
     "build:clear": "rm -rf ./dist",


### PR DESCRIPTION
this allows for a manual review before changes are pushed to master